### PR TITLE
Optimise stats collection

### DIFF
--- a/internal/version/binary.go
+++ b/internal/version/binary.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const Binary = "1.0.0-compat"
+const Binary = "1.0.0-compat-monzo1"
 
 func String(app string) string {
 	return fmt.Sprintf("%s v%s (built w/%s)", app, Binary, runtime.Version())

--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -38,7 +38,7 @@ type ChannelStats struct {
 	ChannelName   string        `json:"channel_name"`
 	Depth         int64         `json:"depth"`
 	BackendDepth  int64         `json:"backend_depth"`
-	InFlightCount int           `json:"in_flight_count"`
+	InFlightCount uint64        `json:"in_flight_count"`
 	DeferredCount int           `json:"deferred_count"`
 	MessageCount  uint64        `json:"message_count"`
 	RequeueCount  uint64        `json:"requeue_count"`
@@ -50,9 +50,6 @@ type ChannelStats struct {
 }
 
 func NewChannelStats(c *Channel, clients []ClientStats) ChannelStats {
-	c.inFlightMutex.Lock()
-	inflight := len(c.inFlightMessages)
-	c.inFlightMutex.Unlock()
 	c.deferredMutex.Lock()
 	deferred := len(c.deferredMessages)
 	c.deferredMutex.Unlock()
@@ -61,7 +58,7 @@ func NewChannelStats(c *Channel, clients []ClientStats) ChannelStats {
 		ChannelName:   c.name,
 		Depth:         c.Depth(),
 		BackendDepth:  c.backend.Depth(),
-		InFlightCount: inflight,
+		InFlightCount: atomic.LoadUint64(&c.inFlightCount),
 		DeferredCount: deferred,
 		MessageCount:  atomic.LoadUint64(&c.messageCount),
 		RequeueCount:  atomic.LoadUint64(&c.requeueCount),

--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -39,7 +39,7 @@ type ChannelStats struct {
 	Depth         int64         `json:"depth"`
 	BackendDepth  int64         `json:"backend_depth"`
 	InFlightCount uint64        `json:"in_flight_count"`
-	DeferredCount int           `json:"deferred_count"`
+	DeferredCount uint64        `json:"deferred_count"`
 	MessageCount  uint64        `json:"message_count"`
 	RequeueCount  uint64        `json:"requeue_count"`
 	TimeoutCount  uint64        `json:"timeout_count"`
@@ -50,16 +50,12 @@ type ChannelStats struct {
 }
 
 func NewChannelStats(c *Channel, clients []ClientStats) ChannelStats {
-	c.deferredMutex.Lock()
-	deferred := len(c.deferredMessages)
-	c.deferredMutex.Unlock()
-
 	return ChannelStats{
 		ChannelName:   c.name,
 		Depth:         c.Depth(),
 		BackendDepth:  c.backend.Depth(),
 		InFlightCount: atomic.LoadUint64(&c.inFlightCount),
-		DeferredCount: deferred,
+		DeferredCount: atomic.LoadUint64(&c.deferredCount),
 		MessageCount:  atomic.LoadUint64(&c.messageCount),
 		RequeueCount:  atomic.LoadUint64(&c.requeueCount),
 		TimeoutCount:  atomic.LoadUint64(&c.timeoutCount),

--- a/nsqd/stats.go
+++ b/nsqd/stats.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 	"sort"
 	"sync/atomic"
+	"time"
 
 	"github.com/nsqio/nsq/internal/quantile"
 )
@@ -121,7 +122,9 @@ type ChannelsByName struct {
 func (c ChannelsByName) Less(i, j int) bool { return c.Channels[i].name < c.Channels[j].name }
 
 func (n *NSQD) GetStats(topic string, channel string) []TopicStats {
+	topicAcquireStart := time.Now()
 	n.RLock()
+	n.logf(LOG_DEBUG, "stats: acquiring topic list - took %v to acquire nsqd lock", time.Since(topicAcquireStart))
 	var realTopics []*Topic
 	if topic == "" {
 		realTopics = make([]*Topic, 0, len(n.topicMap))
@@ -135,10 +138,13 @@ func (n *NSQD) GetStats(topic string, channel string) []TopicStats {
 		return []TopicStats{}
 	}
 	n.RUnlock()
+	n.logf(LOG_DEBUG, "stats: acquired topic list (under lock) in %v", time.Since(topicAcquireStart))
 	sort.Sort(TopicsByName{realTopics})
 	topics := make([]TopicStats, 0, len(realTopics))
 	for _, t := range realTopics {
+		topicLockStart := time.Now()
 		t.RLock()
+		n.logf(LOG_DEBUG, "stats: topic (%v) rlock acquired in %v", time.Since(topicLockStart))
 		var realChannels []*Channel
 		if channel == "" {
 			realChannels = make([]*Channel, 0, len(t.channelMap))
@@ -152,19 +158,29 @@ func (n *NSQD) GetStats(topic string, channel string) []TopicStats {
 			continue
 		}
 		t.RUnlock()
+		n.logf(LOG_DEBUG, "stats: acquired channels (under lock) for topic (%s) in %v", t.name, time.Since(topicLockStart))
 		sort.Sort(ChannelsByName{realChannels})
 		channels := make([]ChannelStats, 0, len(realChannels))
 		for _, c := range realChannels {
+			channelLockStart := time.Now()
 			c.RLock()
 			clients := make([]ClientStats, 0, len(c.clients))
 			for _, client := range c.clients {
 				clients = append(clients, client.Stats())
 			}
 			c.RUnlock()
+			n.logf(LOG_DEBUG, "stats: acquired clients (under lock) for topic/channel (%s/%s) in %v", t.name, c.name, time.Since(channelLockStart))
+			channelStatsStart := time.Now()
 			channels = append(channels, NewChannelStats(c, clients))
+			n.logf(LOG_DEBUG, "stats: acquired channel stats for topic/channel (%s/%s) in %v", t.name, c.name, time.Since(channelStatsStart))
 		}
+
+		topicStatsStart := time.Now()
 		topics = append(topics, NewTopicStats(t, channels))
+		n.logf(LOG_DEBUG, "stats: acquired topic stats for topic (%s) in %v", t.name, time.Since(topicStatsStart))
 	}
+
+	n.logf(LOG_DEBUG, "stats: finished acquiring stats in %v", time.Since(topicAcquireStart))
 	return topics
 }
 

--- a/nsqd/stats_test.go
+++ b/nsqd/stats_test.go
@@ -17,6 +17,7 @@ import (
 func TestStats(t *testing.T) {
 	opts := NewOptions()
 	opts.Logger = test.NewTestLogger(t)
+	opts.LogLevel = "debug"
 	tcpAddr, _, nsqd := mustStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
@@ -112,6 +113,7 @@ func TestClientAttributes(t *testing.T) {
 func TestStatsChannelLocking(t *testing.T) {
 	opts := NewOptions()
 	opts.Logger = test.NewTestLogger(t)
+	opts.LogLevel = "debug"
 	_, _, nsqd := mustStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()

--- a/nsqd/stats_test.go
+++ b/nsqd/stats_test.go
@@ -148,5 +148,5 @@ func TestStatsChannelLocking(t *testing.T) {
 
 	test.Equal(t, 1, len(stats))
 	test.Equal(t, 1, len(stats[0].Channels))
-	test.Equal(t, 25, stats[0].Channels[0].InFlightCount)
+	test.Equal(t, uint64(25), stats[0].Channels[0].InFlightCount)
 }


### PR DESCRIPTION
Makes stats collection in nsqd concurrent, and changes a number of operations to occur without, or outside of locks where possible.

 - **Cache inflight and deferred message counts** within each channel as an atomically accessed `uint64`. Storing this value is executed twice for every message processed, which may impact performance, however it means the stats calls no longer obtain a lock on these maps, so obtaining stats is completely decoupled from the message processing. I suspect this is a point on contention on busy / heavily contended channels.
 - **Gather topic/channel stats concurrently** - previously getting stats iterated all channels and topics (with a filter if provided) and sequentially gathered values. This is now executed concurrently for all topics and channels within each topic.

 The nsq test suite still passes after these changes 😄 