### PR TITLE
Avoid t.Log data races flagged up by the race detector

### DIFF
--- a/nsqlookupd/lookup_protocol_v1_test.go
+++ b/nsqlookupd/lookup_protocol_v1_test.go
@@ -38,6 +38,8 @@ func testIOLoopReturnsClientErr(t *testing.T, fakeConn test.FakeNetConn) {
 
 	prot := &LookupProtocolV1{ctx: &Context{nsqlookupd: New(opts)}}
 
+	prot.ctx.nsqlookupd.tcpServer = &tcpServer{ctx: prot.ctx}
+
 	errChan := make(chan error)
 	testIOLoop := func() {
 		errChan <- prot.IOLoop(fakeConn)


### PR DESCRIPTION
This commit picks https://github.com/nsqio/nsq/pull/1190 and backports it to this version of NSQ to avoid data races in t.Log flagged up by the race detector