### PR TITLE
Fix Dockerfile and GOFLAGS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM golang:latest AS build
+FROM golang:1.16 AS build
+
+RUN go env -w GO111MODULE=auto
 
 RUN mkdir -p /go/src/github.com/nsqio/nsq
 COPY . /go/src/github.com/nsqio/nsq
 
 WORKDIR /go/src/github.com/nsqio/nsq
 
-RUN wget -O /bin/dep https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64 \
+RUN wget -O /bin/dep https://github.com/golang/dep/releases/download/v0.5.4/dep-linux-amd64 \
  && chmod +x /bin/dep \
  && /bin/dep ensure \
  && ./test.sh \
- && CGO_ENABLED=0 make DESTDIR=/opt PREFIX=/nsq GOFLAGS='-ldflags="-s -w"' install
+ && CGO_ENABLED=0 make DESTDIR=/opt PREFIX=/nsq BLDFLAGS='-ldflags="-s -w"' install
 
 FROM alpine:3.6
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX=/usr/local
 DESTDIR=
-GOFLAGS=
+BLDFLAGS=
 BINDIR=${PREFIX}/bin
 
 BLDDIR = build
@@ -25,7 +25,7 @@ $(BLDDIR)/to_nsq:      $(wildcard apps/to_nsq/*.go               internal/*/*.go
 
 $(BLDDIR)/%:
 	@mkdir -p $(dir $@)
-	go build ${GOFLAGS} -o $@ ./apps/$*
+	go build ${BLDFLAGS} -o $@ ./apps/$*
 
 $(APPS): %: $(BLDDIR)/%
 

--- a/dist.sh
+++ b/dist.sh
@@ -20,7 +20,7 @@ rm -rf   $DIR/dist/docker
 mkdir -p $DIR/dist/docker
 dep ensure
 
-GOFLAGS='-ldflags="-s -w"'
+BLDFLAGS='-ldflags="-s -w"'
 arch=$(go env GOARCH)
 version=$(awk '/const Binary/ {print $NF}' < $DIR/internal/version/binary.go | sed 's/"//g')
 goversion=$(go version | awk '{print $3}')
@@ -33,7 +33,7 @@ for os in linux darwin freebsd windows; do
     BUILD=$(mktemp -d ${TMPDIR:-/tmp}/nsq-XXXXX)
     TARGET="nsq-$version.$os-$arch.$goversion"
     GOOS=$os GOARCH=$arch CGO_ENABLED=0 \
-        make DESTDIR=$BUILD PREFIX=/$TARGET GOFLAGS="$GOFLAGS" install
+        make DESTDIR=$BUILD PREFIX=/$TARGET BLDFLAGS="$BLDFLAGS" install
     pushd $BUILD
     if [ "$os" == "linux" ]; then
         cp -r $TARGET/bin $DIR/dist/docker/


### PR DESCRIPTION
Tweaks the Dockerfile to use Go 1.16 and the latest Dep

Also cherry picks https://github.com/nsqio/nsq/pull/1085 as GOFLAGS now is used as an env var so was conflicting with the flags